### PR TITLE
:sparkles: Add CSV parsing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sébastien Watteau <swatteau@gmail.com>"]
 
 [dependencies]
 xml-rs = "~0.3.4"
+csv = "1"
 
 [dev-dependencies]
 assert_matches = "~1.0"

--- a/src/model/map.rs
+++ b/src/model/map.rs
@@ -853,6 +853,8 @@ impl<R: Read> ElementReader<Map> for TmxReader<R> {
                 let orientation = try!(Orientation::from_str(value));
                 map.set_orientation(orientation);
             }
+            "tiledversion" => {}
+            "infinite" => {}
             "renderorder" => {
                 let render_order = try!(RenderOrder::from_str(value));
                 map.set_render_order(render_order);


### PR DESCRIPTION
Right now an application using this library needs to perform some extra work to decode the "raw" data stored in a .tmx files layer data. These can be stored in a few ways but the files I've been dealing with only required CSV support for now so I've added a helper to decode this information and return a vec of global id's.

Potentially this should return a `DataTiles` instead, however the files I've been processing had very large values that failed to parse as `i32` leading to incorrect data. Switching `DataTile` over to store the `gid` as `u32` or `u64` was out of the scope (for me) of this change (and would potentially be a breaking change).

However if that change gets made it would be easy to add the `xml` encoding as well.

This adds a dependency on the `csv` package.